### PR TITLE
Example to reproduce issue2 with istanbul-api

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,7 @@
+check:
+  global:
+    statements: 100
+    lines: 100
+    branches: 100
+    functions: 100
+    excludes: []

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Sample project for demo of running istanbul with mocha using custom compilers",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha -- --compilers js:babel-core/register test/"
+    "test": "istanbul cover _mocha -- --compilers js:babel-core/register test/",
+    "posttest": "istanbul check-coverage"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
     "babel-core": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
     "istanbul": "^1.0.0-alpha.2",
+    "istanbul-api": "^1.0.0-alpha.10",
     "mocha": "^2.3.4"
   }
 }


### PR DESCRIPTION
This change executes the `check-coverage` command in order to reproduce https://github.com/istanbuljs/istanbul-api/issues/2.

After running `npm test` you can see the the result from check-coverage differs from the coverage summary:

```
$ npm test

> sample-mocha-compilers@1.0.0 test /Users/foo/workspace/sample-mocha-compilers
> istanbul cover _mocha -- --compilers js:babel-core/register test/



  rectangle
    ✓ calculates area


  1 passing (404ms)


=============================== Coverage summary ===============================
Statements   : 83.33% ( 10/12 )
Branches     : 50% ( 2/4 )
Functions    : 100% ( 1/1 )
Lines        : 83.33% ( 10/12 )
================================================================================

> sample-mocha-compilers@1.0.0 posttest /Users/foo/workspace/sample-mocha-compilers
> istanbul check-coverage


/Users/foo/workspace/sample-mocha-compilers/node_modules/istanbul/lib/cli.js:38
        throw ex; // turn it into an uncaught exception
        ^
ERROR: Coverage for statements (84.38%) does not meet global threshold (100%)
ERROR: Coverage for branches (57.14%) does not meet global threshold (100%)
ERROR: Coverage for lines (88.89%) does not meet global threshold (100%)
npm ERR! Test failed.  See above for more details.
```
