### PR TITLE
Add test for spread operators and add `check-coverage` npm task to compare with `cover`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    "es2015",
+    "stage-0"
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,13 @@ class Rectangle {
     get area() {
         return this.width * this.height;
     }
+
+    get measures() {
+        let height = { height: this.height };
+        let width = { width: this.width };
+
+        return { ...height, ...width };
+    }
 }
 
 // We export the Rectangle class so it can

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Sample project for demo of running istanbul with mocha using custom compilers",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha -- --compilers js:babel-register test/"
+    "test": "istanbul cover _mocha -- --compilers js:babel-register test/",
+    "check-coverage": "istanbul check-coverage --statements 100 --functions 100 --branches 100 --lines 100"
   },
   "repository": {
     "type": "git",
@@ -22,8 +23,9 @@
   "homepage": "https://github.com/istanbuljs/sample-mocha-compilers#readme",
   "dependencies": {},
   "devDependencies": {
-    "babel-register": "^6.4.3",
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.4.3",
     "istanbul": "^1.0.0-alpha.2",
     "mocha": "^2.3.4"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,5 +6,11 @@ describe('rectangle', function () {
         let r = new Rectangle(10,10);
         assert.ok(r.area === 100);
     });
+
+    it('returns an object', function () {
+        let r = new Rectangle(10, 10);
+        assert.ok(r.measures.width === 10);
+        assert.ok(r.measures.height === 10);
+    });
 });
 


### PR DESCRIPTION
- Add `babel-preset-stage-0` to test spread operators
- Create `check-coverage` so results can be compared with `test` results
- `cover` and `check-coverage` results are currently different, they should be the same:
  ![screen shot 2016-05-20 at 2 06 59 pm](https://cloud.githubusercontent.com/assets/1735844/15442135/fa0dcf3e-1e93-11e6-9bd2-06658ea048a6.png)
- It looks like `check-coverage` checks transpiled files, while `cover` checks the actual source
- I'm currently debugging `istanbul-api` to fix the problem but not being very successful, let me know if you have an idea of the problem and I can try to fix it
